### PR TITLE
Feature gate allocation switching

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -6,3 +6,7 @@ set -e
 mkdir out && cd out
 cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=OFF -Denable_parallel_mark=ON -Dbuild_tests=ON -Denable_gc_assertions=ON ../
 ninja && ninja test
+
+cd .. && rm -rf out && mkdir out && cd out
+cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=OFF -Denable_allocation_switching=ON -Denable_parallel_mark=ON -Dbuild_tests=ON -Denable_gc_assertions=ON ../
+ninja && ninja test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,6 +259,10 @@ if (disable_handle_fork)
   add_definitions("-DNO_HANDLE_FORK")
 endif()
 
+if (enable_allocation_switching)
+    add_definitions("-DALLOC_SWITCHING")
+endif()
+
 if (enable_gcj_support)
   add_definitions("-DGC_GCJ_SUPPORT")
   if (enable_threads AND NOT (enable_thread_local_alloc AND HOST MATCHES .*-.*-kfreebsd.*-gnu))

--- a/allchblk.c
+++ b/allchblk.c
@@ -950,9 +950,12 @@ GC_INNER void GC_freehblk(struct hblk *hbp)
       /* later.                                                             */
     GC_remove_counts(hbp, size);
 
+# if defined(ALLOC_SWITCHING)
     // Clear all the mark bytes to prevent blocks from lingering as managed.
     // Instead, this should only be opted-in on each allocation.
     BZERO(hhdr->hb_marks, sizeof(hhdr->hb_marks));
+# endif
+
     hhdr->hb_sz = size;
 #   ifdef USE_MUNMAP
       hhdr -> hb_last_reclaimed = (unsigned short)GC_gc_no;

--- a/alloc.c
+++ b/alloc.c
@@ -1057,8 +1057,7 @@ STATIC void GC_clear_fl_marks(ptr_t q)
       for (;;) {
         word bit_no = MARK_BIT_NO((ptr_t)q - (ptr_t)h, sz);
 
-        if (mark_bit_from_hdr(hhdr, bit_no) == MANAGED_MARKED ||
-            mark_bit_from_hdr(hhdr, bit_no) == UNMANAGED_MARKED) {
+        if (mark_bit_is_set(hhdr, bit_no)) {
           size_t n_marks = hhdr -> hb_n_marks;
 
           GC_ASSERT(n_marks != 0);

--- a/configure.ac
+++ b/configure.ac
@@ -156,6 +156,9 @@ fi
 AC_ARG_ENABLE(cplusplus,
     [AS_HELP_STRING([--enable-cplusplus], [install C++ support])])
 
+AH_TEMPLATE([ALLOC_SWITCHING], [Define to enable dynamic switching between collectable
+             and uncollectable allocations.])
+
 dnl Features which may be selected in the following thread-detection switch.
 AH_TEMPLATE([PARALLEL_MARK], [Define to enable parallel marking.])
 AH_TEMPLATE([THREAD_LOCAL_ALLOC],

--- a/dbg_mlc.c
+++ b/dbg_mlc.c
@@ -816,7 +816,9 @@ GC_API void GC_CALL GC_debug_free(void * p)
         word sz = hhdr -> hb_sz;
         word obj_sz = BYTES_TO_WORDS(sz - sizeof(oh));
 
+# if defined(ALLOC_SWITCHING)
         if(GC_is_managed(p)) GC_set_unmanaged(p);
+# endif
 
         for (i = 0; i < obj_sz; ++i)
           ((word *)p)[i] = GC_FREED_MEM_MARKER;
@@ -991,7 +993,11 @@ STATIC void GC_check_heap_block(struct hblk *hbp, word dummy GC_ATTR_UNUSED)
     /* go through all words in block */
     for (bit_no = 0; (word)p <= (word)plim;
          bit_no += MARK_BIT_OFFSET(sz), p += sz) {
+# if defined(ALLOC_SWITCHING)
       if (mark_bit_from_hdr(hhdr, bit_no) != MANAGED_UNMARKED && GC_HAS_DEBUG_INFO((ptr_t)p)) {
+# else
+      if (mark_bit_from_hdr(hhdr, bit_no) && GC_HAS_DEBUG_INFO((ptr_t)p)) {
+# endif
         ptr_t clobbered = GC_check_annotated_obj((oh *)p);
         if (clobbered != 0)
           GC_add_smashed(clobbered);

--- a/finalize.c
+++ b/finalize.c
@@ -998,10 +998,18 @@ GC_INNER void GC_finalize(void)
            curr_fo != NULL; curr_fo = fo_next(curr_fo)) {
         GC_ASSERT(GC_size(curr_fo) >= sizeof(struct finalizable_object));
         real_ptr = (ptr_t)GC_REVEAL_POINTER(curr_fo->fo_hidden_base);
+# if defined(ALLOC_SWITCHING)
         if (GC_is_managed_unmarked(real_ptr)) {
+# else
+        if (!GC_is_marked(real_ptr)) {
+# endif
             GC_MARKED_FOR_FINALIZATION(real_ptr);
             GC_MARK_FO(real_ptr, curr_fo -> fo_mark_proc);
+# if defined(ALLOC_SWITCHING)
             if (GC_is_managed_marked(real_ptr)) {
+# else
+            if (GC_is_marked(real_ptr)) {
+# endif
                 WARN("Finalization cycle involving %p\n", real_ptr);
             }
         }
@@ -1015,7 +1023,11 @@ GC_INNER void GC_finalize(void)
       prev_fo = 0;
       while (curr_fo != 0) {
         real_ptr = (ptr_t)GC_REVEAL_POINTER(curr_fo->fo_hidden_base);
+# if defined(ALLOC_SWITCHING)
         if (GC_is_managed_unmarked(real_ptr)) {
+# else
+        if (!GC_is_marked(real_ptr)) {
+# endif
             if (!GC_java_finalization) {
               GC_set_mark_bit(real_ptr);
             }

--- a/fnlz_mlc.c
+++ b/fnlz_mlc.c
@@ -103,7 +103,9 @@ GC_API GC_ATTR_MALLOC void * GC_CALL GC_finalized_malloc(size_t lb,
                                 GC_finalized_kind);
     if (EXPECT(NULL == op, FALSE))
         return NULL;
+# if defined(ALLOC_SWITCHING)
     GC_set_managed(op);
+# endif
     *op = (word)fclos | FINALIZER_CLOSURE_FLAG;
     GC_dirty(op);
     REACHABLE_AFTER_DIRTY(fclos);

--- a/include/gc/gc_mark.h
+++ b/include/gc/gc_mark.h
@@ -290,6 +290,7 @@ GC_API int GC_CALL GC_is_marked(const void *) GC_ATTR_NONNULL(1);
 GC_API void GC_CALL GC_clear_mark_bit(const void *) GC_ATTR_NONNULL(1);
 GC_API void GC_CALL GC_set_mark_bit(const void *) GC_ATTR_NONNULL(1);
 
+# if defined(ALLOC_SWITCHING)
 /* Slow/general manage bit manipulation.  The caller should hold the      */
 /* allocation lock.  GC_is_managed returns 1 (TRUE) or 0.  The argument  */
 /* should be the real address of an object (i.e. the address of the     */
@@ -299,6 +300,7 @@ GC_API int GC_CALL GC_is_managed_marked(const void *) GC_ATTR_NONNULL(1);
 GC_API int GC_CALL GC_is_managed_unmarked(const void *) GC_ATTR_NONNULL(1);
 GC_API void GC_CALL GC_set_managed(const void *) GC_ATTR_NONNULL(1);
 GC_API void GC_CALL GC_set_unmanaged(const void *) GC_ATTR_NONNULL(1);
+# endif
 
 /* Push everything in the given range onto the mark stack.              */
 /* (GC_push_conditional pushes either all or only dirty pages depending */

--- a/include/private/gcconfig.h
+++ b/include/private/gcconfig.h
@@ -2955,7 +2955,7 @@ EXTERN_C_BEGIN
 #endif
 
 #ifndef CLEAR_DOUBLE
-# define CLEAR_DOUBLE(x) (((word*)(x))[0] = 0, ((word*)(x))[1] = 0);
+# define CLEAR_DOUBLE(x) (((word*)(x))[0] = 0, ((word*)(x))[1] = 0)
 #endif
 
 #if defined(GC_LINUX_THREADS) && defined(REDIRECT_MALLOC) \

--- a/mallocx.c
+++ b/mallocx.c
@@ -161,7 +161,9 @@ GC_API void * GC_CALL GC_realloc(void * p, size_t lb)
     }
     result = GC_generic_or_special_malloc((word)lb, obj_kind);
     if (result != NULL) {
+# if defined(ALLOC_SWITCHING)
       if (GC_is_managed(p)) GC_set_managed(result);
+# endif
       /* In case of shrink, it could also return original object.       */
       /* But this gives the client warning of imminent disaster.        */
       BCOPY(p, result, sz);


### PR DESCRIPTION
This can be enabled with the configure flag --enable-alloc-switching or the CMake arg -Denable-allocation-switching=ON.

Feature gating this means we can disable the uncollectable pool entirely in Boehm. This pool relied on lazily clearing the mark bit, which is no longer the case the introducion of an additional managed bit in https://github.com/softdevteam/bdwgc/commit/0f0ccedfb25c18b6404a7e19f6277071b8913c11.

This caused a huge slowdown when allocating lots of uncollectable objects because they were erroneously enqueued for finalization.

No longer using the uncollectable pool also means several branches in allocation and marking fast paths can be removed.