### PR TITLE
Add memory fence to synchronise threads after GC

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+#
+# Build script for continuous integration.
+
+set -e
+mkdir out && cd out
+cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=OFF -Denable_parallel_mark=ON -Dbuild_tests=ON -Denable_gc_assertions=ON ../
+make -j
+ctest

--- a/.buildbot_dockerfile_debian
+++ b/.buildbot_dockerfile_debian
@@ -1,0 +1,9 @@
+FROM debian:bullseye
+ARG CI_UID
+RUN useradd -m -u ${CI_UID} ci
+RUN apt-get update && \
+    apt-get -y install build-essential curl cmake python3 git
+WORKDIR /ci
+RUN chown ${CI_UID}:${CI_UID} .
+COPY --chown=${CI_UID}:${CI_UID} . .
+CMD sh -x .buildbot.sh

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,10 @@
+# The service providing the commit statuses to GitHub.
+status = [
+  "buildbot/buildbot-build-script"
+]
+
+# Allow 30 mins for builds.
+timeout_sec = 1800
+
+# Have bors delete auto-merged branches
+delete_merged_branches = true

--- a/include/private/gc_atomic_ops.h
+++ b/include/private/gc_atomic_ops.h
@@ -62,6 +62,8 @@
 
 # define AO_compiler_barrier() __atomic_signal_fence(__ATOMIC_SEQ_CST)
 
+# define AO_memory_fence() __atomic_thread_fence(__ATOMIC_SEQ_CST)
+
 # if defined(THREAD_SANITIZER) && !defined(AO_USE_ATOMIC_THREAD_FENCE)
     /* Workaround a compiler warning (reported by gcc-11, at least)     */
     /* that atomic_thread_fence is unsupported with thread sanitizer.   */

--- a/include/private/gc_locks.h
+++ b/include/private/gc_locks.h
@@ -269,7 +269,9 @@
       GC_EXTERN volatile unsigned char GC_collecting;
 #     ifdef AO_HAVE_char_store
 #       define ENTER_GC() AO_char_store(&GC_collecting, TRUE)
-#       define EXIT_GC() AO_char_store(&GC_collecting, FALSE)
+#       define EXIT_GC() \
+          AO_memory_fence(); \
+          AO_char_store(&GC_collecting, FALSE)
 #     else
 #       define ENTER_GC() (void)(GC_collecting = TRUE)
 #       define EXIT_GC() (void)(GC_collecting = FALSE)


### PR DESCRIPTION
This allows finalisers which are run on separate threads to have a consistent view of the world when run after collection.