### PR TITLE
Bump large alloc warning limit

### DIFF
--- a/misc.c
+++ b/misc.c
@@ -166,7 +166,7 @@ GC_finalizer_notifier_proc GC_finalizer_notifier =
 #endif
 
 #ifndef GC_LARGE_ALLOC_WARN_INTERVAL
-# define GC_LARGE_ALLOC_WARN_INTERVAL 5
+# define GC_LARGE_ALLOC_WARN_INTERVAL 9999
 #endif
 GC_INNER long GC_large_alloc_warn_interval = GC_LARGE_ALLOC_WARN_INTERVAL;
                         /* Interval between unsuppressed warnings.      */


### PR DESCRIPTION
This effectively silences the large allocation warning. The warning exists because allocating many large pages increases the likelihood that conservative scanning will retain dead memory.

We don't want to suppress all warnings in Boehm, so this is the recommended way in Boehm to disable this warning in particular.