### PR TITLE
Export pthread specific API for Rust

### DIFF
--- a/include/private/specific.h
+++ b/include/private/specific.h
@@ -109,27 +109,14 @@ typedef tsd * GC_key_t;
 #define GC_key_create(key, d) GC_key_create_inner(key)
 GC_INNER int GC_key_create_inner(tsd ** key_ptr);
 GC_INNER int GC_setspecific(tsd * key, void * value);
-#define GC_remove_specific(key) \
-                        GC_remove_specific_after_fork(key, pthread_self())
+GC_INNER void GC_remove_specific(tsd * key);
 GC_INNER void GC_remove_specific_after_fork(tsd * key, pthread_t t);
 
 /* An internal version of getspecific that assumes a cache miss.        */
 GC_INNER void * GC_slow_getspecific(tsd * key, word qtid,
                                     tse * volatile * cache_entry);
 
-GC_INLINE void * GC_getspecific(tsd * key)
-{
-    word qtid = quick_thread_id();
-    tse * volatile * entry_ptr = &(key -> cache[CACHE_HASH(qtid)]);
-    tse * entry = *entry_ptr;   /* Must be loaded only once.    */
-
-    GC_ASSERT(qtid != INVALID_QTID);
-    if (EXPECT(entry -> qtid == qtid, TRUE)) {
-      GC_ASSERT(entry -> thread == pthread_self());
-      return TS_REVEAL_PTR(entry -> value);
-    }
-    return GC_slow_getspecific(key, qtid, entry_ptr);
-}
+GC_INNER void * GC_getspecific(tsd * key);
 
 EXTERN_C_END
 

--- a/include/private/thread_local_alloc.h
+++ b/include/private/thread_local_alloc.h
@@ -70,7 +70,7 @@ EXTERN_C_BEGIN
       /* To avoid "R_AARCH64_ABS64 used with TLS symbol" linker warnings. */
 #     define USE_PTHREAD_SPECIFIC
 #   else
-#     define USE_COMPILER_TLS
+#     define USE_CUSTOM_SPECIFIC
 #   endif
 
 # elif (defined(FREEBSD) \


### PR DESCRIPTION
Boehm's pthread specific API can't be statically linked by default. This commit exports it so that it can be called from Alloy.