### PR TITLE
Ensure GC scans thread locals

### DIFF
--- a/include/gc/gc.h
+++ b/include/gc/gc.h
@@ -2309,4 +2309,7 @@ GC_API void GC_CALL GC_win32_free_heap(void);
   } /* extern "C" */
 #endif
 
+GC_API void GC_init_tls_rootset(void * rootset);
+GC_API void * GC_tls_rootset();
+
 #endif /* GC_H */

--- a/include/private/pthread_support.h
+++ b/include/private/pthread_support.h
@@ -112,6 +112,7 @@ typedef struct GC_StackContext_Rep {
                                 /* GC_call_with_gc_active() of this     */
                                 /* stack (thread); may be NULL.         */
 
+  ptr_t tls_rootset;
 } *GC_stack_context_t;
 
 #ifdef GC_WIN32_THREADS

--- a/pthread_stop_world.c
+++ b/pthread_stop_world.c
@@ -370,6 +370,7 @@ STATIC void GC_suspend_handler_inner(ptr_t dummy, void *context)
   }
   crtn = me -> crtn;
   GC_store_stack_ptr(crtn);
+  crtn -> tls_rootset = GC_tls_rootset();
 # ifdef E2K
     GC_ASSERT(NULL == crtn -> backing_store_end);
     GET_PROCEDURE_STACK_LOCAL(&bs_lo, &stack_size);
@@ -856,6 +857,8 @@ GC_INNER void GC_push_all_stacks(void)
             GC_log_printf("Stack for thread %p is [%p,%p)\n",
                           (void *)(p -> id), (void *)lo, (void *)hi);
 #         endif
+            GC_log_printf("TLS rootset for thread %p is %p\n",
+                          (void *)(p -> id), crtn -> tls_rootset);
 #       endif
         if (NULL == lo) ABORT("GC_push_all_stacks: sp not set!");
         if (crtn -> altstack != NULL && (word)(crtn -> altstack) <= (word)lo
@@ -872,6 +875,7 @@ GC_INNER void GC_push_all_stacks(void)
             GC_sp_corrector((void **)&lo, (void *)(p -> id));
 #       endif
         GC_push_all_stack_sections(lo, hi, traced_stack_sect);
+        GC_mark_and_push_stack(crtn->tls_rootset);
 #       ifdef STACK_GROWS_UP
           total_size += lo - hi;
 #       else

--- a/specific.c
+++ b/specific.c
@@ -215,4 +215,16 @@ GC_INNER void * GC_slow_getspecific(tsd * key, word qtid,
   }
 #endif /* GC_ASSERTIONS */
 
+STATIC __thread void* tls_rootset = NULL;
+
+GC_INNER void GC_init_tls_rootset(void * rootset)
+{
+    tls_rootset = rootset;
+}
+
+GC_INNER void* GC_tls_rootset()
+{
+    return tls_rootset;
+}
+
 #endif /* USE_CUSTOM_SPECIFIC */


### PR DESCRIPTION
Boehm can't locate GC pointers stored inside POSIX thread locals, so this allows Alloy to keeps track of pointers to thread local data, which the GC then uses as part of its marking rootset.