### PR TITLE
Mark TLS roots of scheduling GC thread

### DIFF
--- a/pthread_stop_world.c
+++ b/pthread_stop_world.c
@@ -791,6 +791,11 @@ GC_INNER void GC_push_all_stacks(void)
     pthread_t self = pthread_self();
     word total_size = 0;
 
+    // We need to push the TLS rootset for the current thread (i.e. the thread
+    // which invoked GC). The TLS rootset for all other threads is pushed from
+    // inside their suspend handler.
+    GC_self_thread_inner() -> crtn -> tls_rootset = GC_tls_rootset();
+
     GC_ASSERT(I_HOLD_LOCK());
     GC_ASSERT(GC_thr_initialized);
 #   ifdef DEBUG_THREADS
@@ -875,6 +880,10 @@ GC_INNER void GC_push_all_stacks(void)
             GC_sp_corrector((void **)&lo, (void *)(p -> id));
 #       endif
         GC_push_all_stack_sections(lo, hi, traced_stack_sect);
+#       ifdef DEBUG_THREADS
+        GC_log_printf("Pushing TLS rootset from thread %p\n",
+                (void *)(p -> id), crtn -> tls_rootset);
+#       endif
         GC_mark_and_push_stack(crtn->tls_rootset);
 #       ifdef STACK_GROWS_UP
           total_size += lo - hi;


### PR DESCRIPTION
When a mutator thread schedules a GC, it suspends all other mutator threads by sending SIGPWR signals. Before those other threads are suspended, they push a pointer to their TLS roots to the collector so their TLS roots can be marked.

Since this happened in the suspend signal handler, the TLS roots of the thread that invoked GC are never marked (because the scheduling thread is never suspended!) This fixes that by ensuring the TLS roots of the scheduling thread are pushed when the GC enters the stop the world phase.