### PR TITLE
Add finaliser bit to object header

### DIFF
--- a/include/gc/gc_mark.h
+++ b/include/gc/gc_mark.h
@@ -362,6 +362,11 @@ GC_API int GC_CALL GC_is_marked(const void *) GC_ATTR_NONNULL(1);
 GC_API void GC_CALL GC_clear_mark_bit(const void *) GC_ATTR_NONNULL(1);
 GC_API void GC_CALL GC_set_mark_bit(const void *) GC_ATTR_NONNULL(1);
 
+/* Finalizer queue bit manipulation.                                    */
+GC_API int GC_CALL GC_is_finalizer_bit_set(const void *) GC_ATTR_NONNULL(1);
+GC_API void GC_CALL GC_set_finalizer_bit(const void *) GC_ATTR_NONNULL(1);
+GC_API void GC_CALL GC_clear_finalizer_bit(const void *) GC_ATTR_NONNULL(1);
+
 /* Push everything in the given range onto the mark stack.              */
 /* (GC_push_conditional pushes either all or only dirty pages depending */
 /* on the third argument.)  GC_push_all_eager also ensures that stack   */

--- a/include/gc/gc_mark.h
+++ b/include/gc/gc_mark.h
@@ -363,9 +363,9 @@ GC_API void GC_CALL GC_clear_mark_bit(const void *) GC_ATTR_NONNULL(1);
 GC_API void GC_CALL GC_set_mark_bit(const void *) GC_ATTR_NONNULL(1);
 
 /* Finalizer queue bit manipulation.                                    */
-GC_API int GC_CALL GC_is_finalizer_bit_set(const void *) GC_ATTR_NONNULL(1);
-GC_API void GC_CALL GC_set_finalizer_bit(const void *) GC_ATTR_NONNULL(1);
-GC_API void GC_CALL GC_clear_finalizer_bit(const void *) GC_ATTR_NONNULL(1);
+GC_API int GC_CALL GC_is_finalizer_queued_bit_set(const void *) GC_ATTR_NONNULL(1);
+GC_API void GC_CALL GC_set_finalizer_queued_bit(const void *) GC_ATTR_NONNULL(1);
+GC_API void GC_CALL GC_clear_finalizer_queued_bit(const void *) GC_ATTR_NONNULL(1);
 
 /* Push everything in the given range onto the mark stack.              */
 /* (GC_push_conditional pushes either all or only dirty pages depending */

--- a/include/private/gc_priv.h
+++ b/include/private/gc_priv.h
@@ -1874,9 +1874,13 @@ struct GC_traced_stack_sect_s {
  */
 
 #ifdef USE_MARK_BYTES
-# define mark_bit_from_hdr(hhdr,n) ((hhdr)->hb_marks[n])
-# define set_mark_bit_from_hdr(hhdr,n) ((hhdr)->hb_marks[n] = 1)
-# define clear_mark_bit_from_hdr(hhdr,n) ((hhdr)->hb_marks[n] = 0)
+# define mark_bit_from_hdr(hhdr,n) ((hhdr)->hb_marks[n] & 0x1)
+# define set_mark_bit_from_hdr(hhdr,n) ((hhdr)->hb_marks[n] |= 1)
+# define clear_mark_bit_from_hdr(hhdr,n) ((hhdr)->hb_marks[n] &= ~1)
+
+# define set_finalizer_bit_from_hdr(hhdr,n) ((hhdr)->hb_marks[n] |= (1 << 1))
+# define clear_finalizer_bit_from_hdr(hhdr,n) ((hhdr)->hb_marks[n] &= ~(1 << 1))
+# define finalizer_bit_is_set(hhdr,n) (((hhdr)->hb_marks[n] >> 1) & 1)
 #else
 /* Set mark bit correctly, even if mark bits may be concurrently        */
 /* accessed.                                                            */

--- a/malloc.c
+++ b/malloc.c
@@ -588,7 +588,7 @@ static void free_internal(void *p, hdr *hhdr)
   size_t ngranules = BYTES_TO_GRANULES(sz); /* size in granules */
   int k = hhdr -> hb_obj_kind;
 
-  GC_ASSERT(!GC_is_finalizer_bit_set(p));
+  GC_ASSERT(!GC_is_finalizer_queued_bit_set(p));
 
   GC_bytes_freed += sz;
   if (IS_UNCOLLECTABLE(k)) GC_non_gc_bytes -= sz;

--- a/malloc.c
+++ b/malloc.c
@@ -588,6 +588,8 @@ static void free_internal(void *p, hdr *hhdr)
   size_t ngranules = BYTES_TO_GRANULES(sz); /* size in granules */
   int k = hhdr -> hb_obj_kind;
 
+  GC_ASSERT(!GC_is_finalizer_bit_set(p));
+
   GC_bytes_freed += sz;
   if (IS_UNCOLLECTABLE(k)) GC_non_gc_bytes -= sz;
   if (EXPECT(ngranules <= MAXOBJGRANULES, TRUE)) {

--- a/mark.c
+++ b/mark.c
@@ -287,6 +287,37 @@ GC_INNER void GC_clear_marks(void)
     GC_scan_ptr = NULL;
 }
 
+GC_API void GC_CALL GC_set_finalizer_bit(const void *p)
+{
+    struct hblk *h = HBLKPTR(p);
+    hdr * hhdr = HDR(h);
+    word bit_no = MARK_BIT_NO((word)p - (word)h, hhdr -> hb_sz);
+
+    if (!finalizer_bit_is_set(hhdr, bit_no)) {
+      set_finalizer_bit_from_hdr(hhdr, bit_no);
+    }
+}
+
+GC_API void GC_CALL GC_clear_finalizer_bit(const void *p)
+{
+    struct hblk *h = HBLKPTR(p);
+    hdr * hhdr = HDR(h);
+    word bit_no = MARK_BIT_NO((word)p - (word)h, hhdr -> hb_sz);
+
+    if (finalizer_bit_is_set(hhdr, bit_no)) {
+      clear_finalizer_bit_from_hdr(hhdr, bit_no);
+    }
+}
+
+GC_API int GC_CALL GC_is_finalizer_bit_set(const void *p)
+{
+    struct hblk *h = HBLKPTR(p);
+    hdr * hhdr = HDR(h);
+    word bit_no = MARK_BIT_NO((word)p - (word)h, hhdr -> hb_sz);
+
+    return (int)finalizer_bit_is_set(hhdr, bit_no); /* 0 or 1 */
+}
+
 /* Initiate a garbage collection.  Initiates a full collection if the   */
 /* mark state is invalid.                                               */
 GC_INNER void GC_initiate_gc(void)

--- a/mark.c
+++ b/mark.c
@@ -287,7 +287,7 @@ GC_INNER void GC_clear_marks(void)
     GC_scan_ptr = NULL;
 }
 
-GC_API void GC_CALL GC_set_finalizer_bit(const void *p)
+GC_API void GC_CALL GC_set_finalizer_queued_bit(const void *p)
 {
     struct hblk *h = HBLKPTR(p);
     hdr * hhdr = HDR(h);
@@ -298,7 +298,7 @@ GC_API void GC_CALL GC_set_finalizer_bit(const void *p)
     }
 }
 
-GC_API void GC_CALL GC_clear_finalizer_bit(const void *p)
+GC_API void GC_CALL GC_clear_finalizer_queued_bit(const void *p)
 {
     struct hblk *h = HBLKPTR(p);
     hdr * hhdr = HDR(h);
@@ -309,7 +309,7 @@ GC_API void GC_CALL GC_clear_finalizer_bit(const void *p)
     }
 }
 
-GC_API int GC_CALL GC_is_finalizer_bit_set(const void *p)
+GC_API int GC_CALL GC_is_finalizer_queued_bit_set(const void *p)
 {
     struct hblk *h = HBLKPTR(p);
     hdr * hhdr = HDR(h);


### PR DESCRIPTION
This allows Alloy to track whether or not an object has been enqueued for finalisation for debug purposes.