### PR TITLE
Allow finalized_malloc to delay reclaiming disclaimed objects

### DIFF
--- a/.buildbot_dockerfile_debian
+++ b/.buildbot_dockerfile_debian
@@ -1,4 +1,4 @@
-FROM debian:bullseye
+FROM debian:latest
 ARG CI_UID
 RUN useradd -m -u ${CI_UID} ci
 RUN apt-get update && \

--- a/fnlz_mlc.c
+++ b/fnlz_mlc.c
@@ -49,7 +49,14 @@ STATIC int GC_CALLBACK GC_finalized_disclaim(void *obj)
         GC_ASSERT(!GC_find_leak);
         (*fc->proc)((word *)obj + 1, fc->cd);
     }
+#ifdef DISCLAIM_MARK_CHILDREN
+    /* Prevent the objects reachable from the disclaimed object from    */
+    /* being reclaimed immediately by marking them as live. Useful if   */
+    /* the disclaim function queues objects to be finalised later.      */
+    return 1;
+#else
     return 0;
+#endif
 }
 
 STATIC void GC_register_disclaim_proc_inner(unsigned kind,


### PR DESCRIPTION
This flag allows the objects reachable only from a finalizable object to stay marked until the next GC. This allows the disclaim function to enqueue those objects to be finalised at some later point in time.