### PR TITLE
Flesh out API for malloc with buffered finalization

### DIFF
--- a/include/private/gc_priv.h
+++ b/include/private/gc_priv.h
@@ -1557,6 +1557,8 @@ struct _GC_arrays {
 # ifdef ENABLE_DISCLAIM
 #   define GC_finalized_kind GC_arrays._finalized_kind
     unsigned _finalized_kind;
+#   define GC_fin_q_kind GC_arrays._fin_q_kind
+    unsigned _fin_q_kind;
 # endif
 # define n_root_sets GC_arrays._n_root_sets
 # define GC_excl_table_entries GC_arrays._excl_table_entries

--- a/mark.c
+++ b/mark.c
@@ -183,9 +183,19 @@ GC_INNER void GC_clear_hdr_marks(hdr *hhdr)
     last_bit = FINAL_MARK_BIT((size_t)hhdr->hb_sz);
 # endif
 
-    BZERO(hhdr -> hb_marks, sizeof(hhdr->hb_marks));
+# ifdef BUFFERED_FINALIZATION
+    unsigned i;
+    size_t sz = (size_t)hhdr->hb_sz;
+    unsigned n_marks = (unsigned)FINAL_MARK_BIT(sz);
+
+    for (i = 0; i <= n_marks; i += (unsigned)MARK_BIT_OFFSET(sz)) {
+        hhdr -> hb_marks[i] &= ~1;
+    }
     set_mark_bit_from_hdr(hhdr, last_bit);
     hhdr -> hb_n_marks = 0;
+#else
+    BZERO(hhdr -> hb_marks, sizeof(hhdr->hb_marks));
+#endif
 }
 
 /* Set all mark bits in the header.  Used for uncollectible blocks. */


### PR DESCRIPTION
This introduces a new malloc function `GC_buffered_finalize_malloc` which ensures that unreachable objects are added to a 4KiB thread-local buffer to be later finalized. Once the buffer is full, it's passed to a user supplied closure.

The disclaim API in Boehm has no mechanism for detecting which allocations in a free-list are simply empty and which require finalizing. So in order to get around this we change mark procedure, using an extra bit in the object header to determine whether or not an object has a finalization closure.