### PR TITLE
Add malloc calls for buffered finalization.

### DIFF
--- a/include/gc/gc_disclaim.h
+++ b/include/gc/gc_disclaim.h
@@ -68,6 +68,46 @@ GC_API GC_ATTR_MALLOC GC_ATTR_ALLOC_SIZE(1) void * GC_CALL
         GC_finalized_malloc(size_t /* size */,
             const struct GC_finalizer_closure * /* fc */) GC_ATTR_NONNULL(2);
 
+
+typedef struct GC_finalization_buffer_hdr GC_finalization_buffer_hdr;
+
+struct GC_finalization_buffer_hdr {
+    GC_finalization_buffer_hdr* next;
+};
+
+struct GC_current_buffer {
+    GC_finalization_buffer_hdr* hdr;
+    void** cursor;
+};
+
+/* This API is defined only if the library has been suitably compiled   */
+/* (i.e. with ENABLE_DISCLAIM defined).                                 */
+
+/* Prepare the object kind used by GC_buffered_finalize_malloc.  Call   */
+/* it from your initialization code or, at least, at some point before  */
+/* finalized allocations.  The function is thread-safe.                 */
+GC_API void GC_CALL GC_init_buffered_finalization(void);
+
+/* Allocate an object which is to be finalized.                         */
+/* This function assumes the first word in the allocated block will     */
+/* store the function pointer to the finalizer.                         */
+/* Allocations of this kind are added to a buffer which, when full, is  */
+/* passed to a user supplied closure to invoke their finalizers. It is  */
+/* the responsibility of the user to ensure these objects are finalized.*/
+/* This uses a dedicated object kind with a disclaim procedure, and is  */
+/* more efficient than GC_register_finalizer and friends.               */
+/* GC_init_buffered_finalization must be called before using this.      */
+/* The collector will not reclaim the object during the GC cycle where  */
+/* it was considered unreachable. In addition, objects reachable from   */
+/* the finalizer will be protected from collection until the finalizer  */
+/* has been run.                                                        */
+/* The disclaim procedure is not invoked in the leak-finding mode.      */
+/* There is no debugging version of this allocation API.                */
+GC_API GC_ATTR_MALLOC GC_ATTR_ALLOC_SIZE(1) void * GC_CALL
+        GC_buffered_finalize_malloc(size_t);
+
+GC_API void GC_CALL GC_finalize_objects(void);
+
 #ifdef __cplusplus
   } /* extern "C" */
 #endif

--- a/include/private/gc_priv.h
+++ b/include/private/gc_priv.h
@@ -1557,6 +1557,8 @@ struct _GC_arrays {
 # ifdef ENABLE_DISCLAIM
 #   define GC_finalized_kind GC_arrays._finalized_kind
     unsigned _finalized_kind;
+#   define GC_fin_q_kind GC_arrays._fin_q_kind
+    unsigned _fin_q_kind;
 # endif
 # define n_root_sets GC_arrays._n_root_sets
 # define GC_excl_table_entries GC_arrays._excl_table_entries

--- a/misc.c
+++ b/misc.c
@@ -1422,6 +1422,10 @@ GC_API void GC_CALL GC_init(void)
 #   if defined(GWW_VDB) && !defined(KEEP_BACK_PTRS)
       GC_ASSERT(GC_bytes_allocd + GC_bytes_allocd_before_gc == 0);
 #   endif
+
+# ifdef BUFFERED_FINALIZATION
+  GC_init_buffered_finalization();
+# endif
 }
 
 GC_API void GC_CALL GC_enable_incremental(void)


### PR DESCRIPTION
This is the first stage of our new finalisation approach in Alloy. It introduces a new malloc function `GC_buffered_finalize_malloc` which ensures that unreachable objects are added to buffers to be later finalised.

This API assumes that the first word in the block allocated with `GC_buffered_finalize_malloc` will contain the function pointer to the block's finaliser. This word must also be tagged in order to differentiate it from an empty block (where the first word is used as a threaded freelist implementation).

The function `GC_finalize_objects` can then be called by the application (either on-demand or in a separate thread) in order to iterate through the chain of buffers and finalise objects. Because this happens on a mutator (i.e. application) thread, it will be paused when the collector stops the word.