### PR TITLE
Add memalign and posix_memalign methods for buffered finalization

### DIFF
--- a/include/gc/gc_disclaim.h
+++ b/include/gc/gc_disclaim.h
@@ -95,6 +95,12 @@ GC_API void GC_CALL GC_init_buffered_finalization(void);
 GC_API GC_ATTR_MALLOC GC_ATTR_ALLOC_SIZE(1) void * GC_CALL
         GC_buffered_finalize_malloc(size_t);
 
+GC_API GC_ATTR_MALLOC GC_ATTR_ALLOC_SIZE(2) void * GC_CALL
+        GC_buffered_finalize_memalign(size_t /* align */, size_t /* lb */);
+
+GC_API int GC_CALL GC_buffered_finalize_posix_memalign(void ** /* memptr */, size_t /* align */,
+                        size_t /* lb */) GC_ATTR_NONNULL(1);
+
 GC_API void GC_CALL GC_finalize_objects(void);
 
 #ifdef __cplusplus

--- a/tests/gctest.c
+++ b/tests/gctest.c
@@ -194,6 +194,10 @@
 # define INIT_PERF_MEASUREMENT GC_start_performance_measurement()
 #endif
 
+# ifdef BUFFERED_FINALIZATION
+#   include "gc/gc_disclaim.h"
+# endif
+
 #define GC_COND_INIT() \
     INIT_FORK_SUPPORT; INIT_MANUAL_VDB_ALLOWED; INIT_PAGES_EXECUTABLE; \
     GC_OPT_INIT; CHECK_GCLIB_VERSION; \
@@ -1663,6 +1667,31 @@ static void run_one_test(void)
           CHECK_OUT_OF_MEMORY(p);
           AO_fetch_and_add1(&collectable_count);
       }
+#     ifdef BUFFERED_FINALIZATION
+        {
+            size_t i;
+            void *p;
+
+            GC_init();
+
+            p = GC_buffered_finalize_malloc(17);
+            CHECK_OUT_OF_MEMORY(p);
+            AO_fetch_and_add1(&collectable_count);
+
+            for (i = sizeof(GC_word); i <= HBLKSIZE * 4; i *= 2) {
+              p = checkOOM(GC_buffered_finalize_memalign(i, 17));
+              AO_fetch_and_add1(&collectable_count);
+              if ((GC_word)p % i != 0 || *(int *)p != 0) {
+                GC_printf("GC_buffered_finalize_posix_memalign(%u,17) produced incorrect result: %p\n",
+                          (unsigned)i, p);
+                FAIL;
+              }
+            }
+            (void)GC_buffered_finalize_posix_memalign(&p, 64, 1);
+            CHECK_OUT_OF_MEMORY(p);
+            AO_fetch_and_add1(&collectable_count);
+        }
+#     endif
 #     ifndef GC_NO_VALLOC
         {
           void *p = checkOOM(GC_valloc(78));


### PR DESCRIPTION
The Rust compiler uses these methods instead of generic malloc under certain conditions and without support we can get rustc assertion errors in standard library methods which expect certain alignment requirements.

This uses the same allocation semantics from existing `GC_memalign` and `GC_posix_memalign` definitions inside mallocx.c