### PR TITLE
Bump rootset count to large configuration

### DIFF
--- a/include/private/gc_priv.h
+++ b/include/private/gc_priv.h
@@ -1286,7 +1286,7 @@ struct hblk {
 # ifdef LARGE_CONFIG
 #   define MAX_ROOT_SETS 8192
 # elif !defined(SMALL_CONFIG)
-#   define MAX_ROOT_SETS 2048
+#   define MAX_ROOT_SETS 8192
 # else
 #   define MAX_ROOT_SETS 512
 # endif


### PR DESCRIPTION
The rootset count is now used for more than just tracking statics and thread-locals: finalisation buffers are added so they are kept alive before they are processed. This does not require any additional memory inside internal GC data structures.