### PR TITLE
Fix CMAKE compiler warnings

### DIFF
--- a/fnlz_mlc.c
+++ b/fnlz_mlc.c
@@ -55,14 +55,7 @@ STATIC int GC_CALLBACK GC_finalized_disclaim(void *obj)
         GC_ASSERT(!GC_find_leak);
         (*fc->proc)((word *)obj + 1, fc->cd);
     }
-#ifdef DISCLAIM_MARK_CHILDREN
-    /* Prevent the objects reachable from the disclaimed object from    */
-    /* being reclaimed immediately by marking them as live. Useful if   */
-    /* the disclaim function queues objects to be finalised later.      */
-    return 1;
-#else
     return 0;
-#endif
 }
 
 STATIC void GC_register_disclaim_proc_inner(unsigned kind,

--- a/include/gc/gc_disclaim.h
+++ b/include/gc/gc_disclaim.h
@@ -69,6 +69,7 @@ GC_API GC_ATTR_MALLOC GC_ATTR_ALLOC_SIZE(1) void * GC_CALL
             const struct GC_finalizer_closure * /* fc */) GC_ATTR_NONNULL(2);
 
 
+#ifdef BUFFERED_FINALIZATION
 /* This API is defined only if the library has been suitably compiled   */
 /* (i.e. with ENABLE_DISCLAIM defined).                                 */
 
@@ -104,6 +105,8 @@ GC_API int GC_CALL GC_buffered_finalize_posix_memalign(void ** /* memptr */, siz
 GC_API void GC_CALL GC_finalize_objects(void);
 
 GC_API size_t GC_finalized_total(void);
+
+#endif
 
 #ifdef __cplusplus
   } /* extern "C" */

--- a/misc.c
+++ b/misc.c
@@ -37,6 +37,10 @@
 # include <floss.h>
 #endif
 
+#ifdef BUFFERED_FINALIZATION
+# include "gc/gc_disclaim.h"
+#endif
+
 #ifdef THREADS
 # ifdef PCR
 #   include "il/PCR_IL.h"


### PR DESCRIPTION
This ensures the correct function definitions are conditionally defined when building Alloy with `-DBUFFERED_FINALIZATION`.  