### PR TITLE
Reimplement finalize count API

### DIFF
--- a/include/gc/gc.h
+++ b/include/gc/gc.h
@@ -220,6 +220,10 @@ GC_API GC_ATTR_DEPRECATED int GC_finalize_on_demand;
 GC_API void GC_CALL GC_set_finalize_on_demand(int);
 GC_API int GC_CALL GC_get_finalize_on_demand(void);
 
+/* Returns the total number of finalizers that have been run so far     */
+/* by the collector.                                                    */
+GC_API size_t GC_CALL GC_finalized_total(void);
+
 GC_API GC_ATTR_DEPRECATED int GC_java_finalization;
                         /* Mark objects reachable from finalizable      */
                         /* objects in a separate post-pass.  This makes */

--- a/include/private/gc_priv.h
+++ b/include/private/gc_priv.h
@@ -1432,6 +1432,8 @@ struct _GC_arrays {
         /* Bytes of memory explicitly deallocated while         */
         /* finalizers were running.  Used to approximate memory */
         /* explicitly deallocated by finalizers.                */
+  size_t _finalizers_run;
+        /* Number of finalizers that have been run so far.      */
   bottom_index *_all_bottom_indices;
         /* Pointer to the first (lowest address) bottom_index;  */
         /* assumes the allocator lock is held.                  */
@@ -1711,6 +1713,7 @@ GC_API_PRIV GC_FAR struct _GC_arrays GC_arrays;
 #define GC_composite_in_use GC_arrays._composite_in_use
 #define GC_excl_table GC_arrays._excl_table
 #define GC_finalizer_bytes_freed GC_arrays._finalizer_bytes_freed
+#define GC_finalizers_run GC_arrays._finalizers_run
 #define GC_heapsize GC_arrays._heapsize
 #define GC_large_allocd_bytes GC_arrays._large_allocd_bytes
 #define GC_large_free_bytes GC_arrays._large_free_bytes

--- a/reclaim.c
+++ b/reclaim.c
@@ -894,7 +894,7 @@ static void* init_finalize_thread(void *arg)
     }
     flzr_can_work = 0;
     pthread_mutex_unlock(&flzr_mtx);
-    GC_invoke_finalizers();
+    GC_finalizers_run += GC_invoke_finalizers();
   }
   return arg;
 }
@@ -915,4 +915,9 @@ GC_INNER void GC_maybe_wake_finalizer_thread()
   flzr_can_work = 1;
   pthread_cond_signal(&flzr_t_has_work);
   pthread_mutex_unlock(&flzr_mtx);
+}
+
+GC_API size_t GC_finalized_total()
+{
+  return GC_finalizers_run;
 }


### PR DESCRIPTION
Our benchmaring harness for Alloy counts the number of finalisers that have been run, and BDWGC provided a mechanism for this under our old -DBUFFERED_FINALIZATION approach. This commit reimplements this for the GC_finalize API.