### PR TITLE
Prevent collection of `uncollectable` allocations

### DIFF
--- a/allchblk.c
+++ b/allchblk.c
@@ -1043,7 +1043,11 @@ GC_INNER void GC_freehblk(struct hblk *hbp)
       /* space at once.  If we don't catch it here, strange things happen   */
       /* later.                                                             */
 
+    // Clear all the mark bytes to prevent blocks from lingering as
+    // uncollectable. Instead, this should only be opted-in on each allocation.
+    BZERO(hhdr->hb_marks, sizeof(hhdr->hb_marks));
     GC_remove_counts(hbp, (size_t)size);
+
     hhdr -> hb_sz = size;
 #   ifdef USE_MUNMAP
       hhdr -> hb_last_reclaimed = (unsigned short)GC_gc_no;

--- a/include/private/gc_pmark.h
+++ b/include/private/gc_pmark.h
@@ -153,7 +153,7 @@ GC_INLINE mse * GC_push_obj(ptr_t obj, const hdr * hhdr, mse * mark_stack_top,
       { /* cannot use do-while(0) here */ \
         char * mark_byte_addr = (char *)(hhdr)->hb_marks + (bit_no); \
         if (*mark_byte_addr != 0) break; /* go to the enclosing loop end */ \
-        *mark_byte_addr = 1; \
+        *mark_byte_addr |= MARK_TAG; \
       }
 # endif /* !PARALLEL_MARK */
 #else

--- a/mallocx.c
+++ b/mallocx.c
@@ -165,6 +165,8 @@ GC_API void * GC_CALL GC_realloc(void * p, size_t lb)
     }
     result = GC_generic_or_special_malloc((word)lb, obj_kind);
     if (EXPECT(result != NULL, TRUE)) {
+      if(GC_is_uncollectable(p))
+        GC_set_uncollectable(result);
       /* In case of shrink, it could also return original object.       */
       /* But this gives the client warning of imminent disaster.        */
       BCOPY(p, result, sz);

--- a/mark.c
+++ b/mark.c
@@ -187,8 +187,13 @@ GC_INNER void GC_clear_hdr_marks(hdr *hhdr)
     /* No race as GC_realloc holds the allocator lock while updating hb_sz. */
     last_bit = FINAL_MARK_BIT((size_t)hhdr->hb_sz);
 # endif
+    unsigned i;
+    size_t sz = (size_t)hhdr->hb_sz;
+    unsigned n_marks = (unsigned)FINAL_MARK_BIT(sz);
 
-    BZERO(hhdr -> hb_marks, sizeof(hhdr->hb_marks));
+    for (i = 0; i <= n_marks; i += (unsigned)MARK_BIT_OFFSET(sz)) {
+        hhdr -> hb_marks[i] &= ~MARK_TAG;
+    }
     set_mark_bit_from_hdr(hhdr, last_bit);
     hhdr -> hb_n_marks = 0;
 }


### PR DESCRIPTION
This modifies the collector so that allocations with the uncollectable flag set are never considered garbage during sweeping.

This allows for switching between collectable and uncollectable allocations during runtime.