### PR TITLE
Add API for tracking reclaimed objects

### DIFF
--- a/include/gc/gc.h
+++ b/include/gc/gc.h
@@ -208,6 +208,9 @@ GC_API int GC_CALL GC_get_finalize_on_demand(void);
 /* Returns the total number of finalizers that have been run so far     */
 /* by the collector.                                                    */
 GC_API size_t GC_CALL GC_finalized_total(void);
+/* Returns the total number of objects that have been reclaimed so far  */
+/* by the collector.                                                    */
+GC_API size_t GC_CALL GC_objects_reclaimed(void);
 
 /* Mark objects reachable from finalizable objects in a separate        */
 /* post-pass.  This makes it a bit safer to use                         */

--- a/include/private/gc_priv.h
+++ b/include/private/gc_priv.h
@@ -1371,6 +1371,7 @@ struct _GC_arrays {
   word _finalizer_bytes_freed;
   /* Number of finalizers that have been run so far.      */
   size_t _finalizers_run;
+  size_t _total_objects_reclaimed;
   /* Pointer to the first (lowest address) bottom_index; assumes the    */
   /* allocator lock is held.                                            */
   bottom_index *_all_bottom_indices;
@@ -1679,6 +1680,7 @@ GC_API_PRIV GC_FAR struct _GC_arrays GC_arrays;
 #define GC_excl_table GC_arrays._excl_table
 #define GC_finalizer_bytes_freed GC_arrays._finalizer_bytes_freed
 #define GC_finalizers_run GC_arrays._finalizers_run
+#define GC_total_objects_reclaimed GC_arrays._total_objects_reclaimed
 #define GC_heapsize GC_arrays._heapsize
 #define GC_large_allocd_bytes GC_arrays._large_allocd_bytes
 #define GC_large_free_bytes GC_arrays._large_free_bytes


### PR DESCRIPTION
This is needed in order to track how many things in a program are actually 'managed' by the collector -- i.e. `Gc<T>s` and any heap allocated components of `T` which are transitively owned by the `Gc<T>` but not directly allocated by it.

Without this API, we used a hodgepodge of recorded leaks, elided finalizers, ratios to previously converted programs, etc to gain a rough estimate for this figure. This turned out to be pretty inaccurate and I didn't trust the numbers.