### PR TITLE
Revert finalization thread

### DIFF
--- a/include/private/gc_priv.h
+++ b/include/private/gc_priv.h
@@ -380,13 +380,12 @@ typedef struct hblkhdr hdr;
 EXTERN_C_BEGIN
 
 #ifndef GC_NO_FINALIZATION
-  GC_INNER void GC_maybe_wake_finalizer_thread(void);
+  GC_INNER void GC_notify_or_invoke_finalizers(void);
   /* If GC_finalize_on_demand is not set, invoke eligible           */
   /* finalizers.  Otherwise: call (*GC_finalizer_notifier)() if     */
   /* there are finalizers to be run, and we have not called this    */
   /* procedure yet this collection cycle.                           */
-# define GC_INVOKE_FINALIZERS() GC_maybe_wake_finalizer_thread()
-  GC_INNER void GC_notify_or_invoke_finalizers(void);
+# define GC_INVOKE_FINALIZERS() GC_notify_or_invoke_finalizers()
 
   /* Perform all indicated finalization actions on unmarked         */
   /* objects.  Unreachable finalizable objects are enqueued for     */

--- a/reclaim.c
+++ b/reclaim.c
@@ -25,14 +25,6 @@
 /* originally on free lists which we had to drop.                       */
 GC_INNER signed_word GC_bytes_found = 0;
 
-#ifdef GC_PTHREADS
-static pthread_mutex_t flzr_mtx = PTHREAD_MUTEX_INITIALIZER;
-static pthread_cond_t flzr_t_has_work = PTHREAD_COND_INITIALIZER;
-static int flzr_can_work = 0;
-#elif
-#error "This fork of BDWGC only supports POSIX threads"
-#endif
-
 #if defined(PARALLEL_MARK)
   /* Number of threads currently building free lists without holding    */
   /* the allocator lock.  It is not safe to collect if this is nonzero. */
@@ -60,8 +52,6 @@ STATIC unsigned GC_n_leaked = 0;
 #if !defined(EAGER_SWEEP) && defined(ENABLE_DISCLAIM)
   STATIC void GC_reclaim_unconditionally_marked(void);
 #endif
-
-STATIC unsigned GC_finalizer_thread_exists = 0;
 
 GC_INLINE void GC_add_leaked(ptr_t leaked)
 {
@@ -896,43 +886,6 @@ GC_API void GC_CALL GC_enumerate_reachable_objects_inner(
   ed.proc = proc;
   ed.client_data = client_data;
   GC_apply_to_all_blocks(GC_do_enumerate_reachable_objects, &ed);
-}
-
-static void* init_finalize_thread(void *arg)
-{
-  while(1) {
-    pthread_mutex_lock(&flzr_mtx);
-    while (flzr_can_work == 0) {
-      pthread_cond_wait(&flzr_t_has_work, &flzr_mtx);
-    }
-    flzr_can_work = 0;
-    pthread_mutex_unlock(&flzr_mtx);
-    GC_finalizers_run += GC_invoke_finalizers();
-  }
-  return arg;
-}
-
-GC_INNER void GC_maybe_wake_finalizer_thread()
-{
-  if (!GC_finalizer_thread_exists) {
-    pthread_t t;
-    pthread_create(&t, NULL, init_finalize_thread, NULL /* arg */);
-    GC_finalizer_thread_exists = 1;
-    return;
-  }
-
-  if (GC_should_invoke_finalizers() == 0)
-    return;
-
-  pthread_mutex_lock(&flzr_mtx);
-  flzr_can_work = 1;
-  pthread_cond_signal(&flzr_t_has_work);
-  pthread_mutex_unlock(&flzr_mtx);
-}
-
-GC_API size_t GC_finalized_total()
-{
-  return GC_finalizers_run;
 }
 
 GC_API size_t GC_reclaimed_objects()


### PR DESCRIPTION
This is now handled externally inside Alloy using the finalizer notifier API [1].

[1]: https://github.com/softdevteam/alloy/pull/177