### PR TITLE
Add callbacks for stat logging

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -3,22 +3,13 @@
 # Build script for continuous integration.
 
 set -e
-mkdir out && cd out
+mkdir static && cd static
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=OFF -Denable_parallel_mark=ON -Dbuild_tests=ON -Denable_gc_assertions=ON ../
 make -j
 ctest
 
-# Build alloy and test it against our BDWGC fork
-
-cd ../
-
-export CARGO_HOME="`pwd`/.cargo"
-export RUSTUP_HOME="`pwd`/.rustup"
-
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup.sh
-sh rustup.sh --default-host x86_64-unknown-linux-gnu \
-    --default-toolchain nightly \
-    --no-modify-path \
-    --profile minimal \
-    -y
-export PATH=`pwd`/.cargo/bin/:$PATH
+cd ..
+mkdir dynamic && cd dynamic
+cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON -Denable_parallel_mark=OFF -Dbuild_tests=ON -Denable_gc_assertions=ON ../
+make -j
+ctest

--- a/alloc.c
+++ b/alloc.c
@@ -83,6 +83,11 @@ word GC_gc_no = 0;
     return full_gc_total_time;
   }
 
+  GC_API unsigned GC_CALL GC_get_full_gc_total_ns_frac(void)
+  {
+    return full_gc_total_ns_frac;
+  }
+
   GC_API unsigned long GC_CALL GC_get_stopped_mark_total_time(void)
   {
     return stopped_mark_total_time;
@@ -501,24 +506,7 @@ STATIC void GC_maybe_gc(void)
     GC_COND_LOG_PRINTF(
                 "***>Full mark for collection #%lu after %lu allocd bytes\n",
                 (unsigned long)GC_gc_no + 1, (unsigned long)GC_bytes_allocd);
-    if (GC_benchmark && GC_gc_no == 0) {
-        GC_BENCHMARK_LOG_PRINTF(
-            "collection_number,"
-            "kind,"
-            "heap_size_on_entry,"
-            "time_marking_ms,"
-            "time_marking_ns,"
-            "bytes_freed,"
-            "live_objects_with_finalizers,"
-            "objects_in_finalizer_queue,"
-            "time_fin_q_ms,"
-            "time_fin_q_ns,"
-            "time_sweeping_ms,"
-            "time_sweeping_ns,"
-            "time_total_ms,"
-            "time_total_ns\n"
-        );
-    }
+    GC_BENCHMARK_LOG_MAYBE_HEADER();
     GC_BENCHMARK_LOG_PRINTF("%lu,major,%lu,",(unsigned long)GC_gc_no + 1,(unsigned long)GC_bytes_allocd);
     GC_promote_black_lists();
     (void)GC_reclaim_all((GC_stop_func)0, TRUE);
@@ -660,7 +648,7 @@ GC_INNER GC_bool GC_try_to_collect_inner(GC_stop_func stop_func)
           GC_log_printf("Complete collection took %lu ms %lu ns\n",
                         time_diff, ns_frac_diff);
         if (GC_benchmark)
-          GC_log_printf("%lu,%lu\n",time_diff, ns_frac_diff);
+          GC_log_printf("%lu,%lu,",time_diff, ns_frac_diff);
       }
 #   endif
     if (GC_on_collection_event)
@@ -872,24 +860,7 @@ STATIC GC_bool GC_stopped_mark(GC_stop_func stop_func)
     GC_COND_LOG_PRINTF(
               "\n--> Marking for collection #%lu after %lu allocated bytes\n",
               (unsigned long)GC_gc_no + 1, (unsigned long)GC_bytes_allocd);
-    if (GC_benchmark && GC_gc_no == 0) {
-        GC_BENCHMARK_LOG_PRINTF(
-            "collection_number,"
-            "kind,"
-            "heap_size_on_entry,"
-            "time_marking_ms,"
-            "time_marking_ns,"
-            "bytes_freed,"
-            "live_objects_with_finalizers,"
-            "objects_in_finalizer_queue,"
-            "time_fin_q_ms,"
-            "time_fin_q_ns,"
-            "time_sweeping_ms,"
-            "time_sweeping_ns,"
-            "time_total_ms,"
-            "time_total_ns\n"
-        );
-    }
+    GC_BENCHMARK_LOG_MAYBE_HEADER();
     GC_BENCHMARK_LOG_PRINTF("%lu,minor,%lu,",(unsigned long)GC_gc_no + 1,(unsigned long)GC_bytes_allocd);
 
 #   ifndef NO_CLOCK

--- a/finalize.c
+++ b/finalize.c
@@ -1439,6 +1439,15 @@ GC_INNER void GC_notify_or_invoke_finalizers(void)
 #   define IF_LONG_REFS_PRESENT_ELSE(x,y) (y)
 # endif
 
+  GC_API unsigned long GC_CALL GC_get_total_finalization_ready_objects(void)
+  {
+    const struct finalizable_object *fo;
+    unsigned long ready = 0;
+    for (fo = GC_fnlz_roots.finalize_now; fo != NULL; fo = fo_next(fo))
+      ++ready;
+    return ready;
+  }
+
   GC_INNER void GC_print_finalization_stats(void)
   {
     const struct finalizable_object *fo;

--- a/include/gc/gc.h
+++ b/include/gc/gc.h
@@ -427,6 +427,13 @@ GC_API void GC_CALL GC_start_performance_measurement(void);
 /* each collection to GC_LOG_FILE.                                      */
 GC_API void GC_CALL GC_enable_benchmark_stats(void);
 
+GC_API void GC_CALL GC_log_metrics(GC_word finalizers_run,
+                                  GC_word finalizers_registered,
+                                  GC_word allocated_gc,
+                                  GC_word allocated_rc,
+                                  GC_word allocated_boxed,
+                                  int final);
+
 /* Get the total time of all full collections since the start of the    */
 /* performance measurements.  Includes time spent in the supplementary  */
 /* actions like blacklists promotion, marks clearing, free lists        */
@@ -435,6 +442,10 @@ GC_API void GC_CALL GC_enable_benchmark_stats(void);
 /* The function does not use any synchronization.  Defined only if the  */
 /* library has been compiled without NO_CLOCK.                          */
 GC_API unsigned long GC_CALL GC_get_full_gc_total_time(void);
+
+GC_API unsigned GC_CALL GC_get_full_gc_total_ns_frac(void);
+
+GC_API unsigned long GC_CALL GC_get_total_finalization_ready_objects(void);
 
 /* Same as GC_get_full_gc_total_time but takes into account all mark    */
 /* phases with the world stopped and nothing else.                      */

--- a/include/private/gc_priv.h
+++ b/include/private/gc_priv.h
@@ -2753,6 +2753,33 @@ GC_API_PRIV void GC_log_printf(const char * format, ...)
 # define GC_ERRINFO_PRINTF GC_log_printf
 #endif
 
+#define GC_BENCHMARK_LOG_MAYBE_HEADER() \
+    do { \
+        if (GC_benchmark && GC_gc_no == 0) { \
+            GC_BENCHMARK_LOG_PRINTF( \
+                "collection_number," \
+                "kind," \
+                "heap_size_on_entry," \
+                "time_marking_ms," \
+                "time_marking_ns," \
+                "bytes_freed," \
+                "live_objects_with_finalizers," \
+                "objects_in_finalizer_queue," \
+                "time_fin_q_ms," \
+                "time_fin_q_ns," \
+                "time_sweeping_ms," \
+                "time_sweeping_ns," \
+                "time_total_ms," \
+                "time_total_ns," \
+                "finalizers_run," \
+                "finalizers_registered," \
+                "allocated_gc," \
+                "allocated_rc," \
+                "allocated_boxed\n" \
+            ); \
+        } \
+    } while (0)
+
 /* Convenient macros for GC_[verbose_]log_printf invocation.    */
 #define GC_BENCHMARK_LOG_PRINTF \
                 if (EXPECT(!GC_benchmark, TRUE)) {} else GC_log_printf

--- a/misc.c
+++ b/misc.c
@@ -14,6 +14,7 @@
  * modified is included with the above copyright notice.
  */
 
+#include "include/gc/gc.h"
 #include "private/gc_pmark.h"
 
 #include <limits.h>
@@ -2806,4 +2807,42 @@ GC_API void GC_CALL GC_abort_on_oom(void)
 GC_API size_t GC_CALL GC_get_hblk_size(void)
 {
     return (size_t)HBLKSIZE;
+}
+
+GC_API void GC_CALL GC_log_metrics(GC_word finalizers_run,
+                                  GC_word finalizers_registered,
+                                  GC_word allocated_gc,
+                                  GC_word allocated_rc,
+                                  GC_word allocated_boxed,
+                                  int final)
+{
+    if (final == 1) {
+        GC_BENCHMARK_LOG_MAYBE_HEADER();
+        GC_BENCHMARK_LOG_PRINTF("-1," // Sentinel collection number
+                                "final," // Kind
+                                "%lu,"
+                                "0,"    // Time marking ms (n/a)
+                                "0,"    // Time marking ns (n/a)
+                                "0,"    // Bytes freed (n/a)
+                                "%lu,%lu,"
+                                "0,"    // Time in fin q ms (n/a)
+                                "0,"    // Time in fin q ns (n/a)
+                                "0,"    // Time sweeping ms (n/a)
+                                "0,"    // Time sweeping ns (n/a)
+                                "%lu,%u,",
+                                (unsigned long) GC_bytes_allocd,
+                                (unsigned long) GC_fo_entries,
+                                GC_get_total_finalization_ready_objects(),
+                                GC_get_full_gc_total_time(),
+                                GC_get_full_gc_total_ns_frac());
+
+
+    }
+    GC_BENCHMARK_LOG_PRINTF("%lu,%lu,%lu,%lu,%lu\n",
+                            (unsigned long) finalizers_run,
+                            (unsigned long) finalizers_registered,
+                            (unsigned long) allocated_gc,
+                            (unsigned long) allocated_rc,
+                            (unsigned long) allocated_boxed);
+
 }


### PR DESCRIPTION
This allows us to record the running total of interesting Alloy properties (e.g. finalizers run, current GC allocations, etc) at each collection pause.